### PR TITLE
Expose the patch when calling onRemote

### DIFF
--- a/chainpad-netflux.js
+++ b/chainpad-netflux.js
@@ -120,10 +120,11 @@ var factory = function (Netflux) {
                 wcObject.send(msg, cb, curve);
             });
 
-            chainpad.onPatch(function () {
+            chainpad.onPatch(function (patch) {
                 if (config.onRemote) {
                     config.onRemote({
-                        realtime: chainpad
+                        realtime: chainpad,
+                        patch
                     });
                 }
             });


### PR DESCRIPTION
This removes the need to recompute the diff between the (old) local content and the (new) remote content (e.g. to update the caret position) which can improve performance when editing large content (considering that the diff is currently recomputed almost on each change). Adding my own patch listener is not helping because this listener is called first, and in my case the local content update can be asynchronous sometimes and the logic to wait for the local content to be updated is in onRemote (that is called first).